### PR TITLE
Revamp GamepadButton

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/modular/GamepadButton.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/modular/GamepadButton.kt
@@ -2,13 +2,13 @@ package org.firstinspires.ftc.teamcode.modular
 
 import kotlin.reflect.KCallable
 
-class GamepadButton(private val gamepad: GamepadState, private val button: KCallable<*>) {
+class GamepadButton(private val gamepad: GamepadState, private val button: KCallable<Boolean>) {
 
     val isToggled: Boolean
-        get() = this.button.call(this.gamepad.current) as Boolean && !(this.button.call(this.gamepad.past) as Boolean)
+        get() = this.button.call(this.gamepad.current) && !this.button.call(this.gamepad.past)
 
     val isPressed: Boolean
-        get() = this.button.call(this.gamepad.current) as Boolean
+        get() = this.button.call(this.gamepad.current)
 
     fun ifIsToggled(block: () -> Unit) {
         if (this.isToggled) block()

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/modular/GamepadButton.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/modular/GamepadButton.kt
@@ -11,11 +11,11 @@ class GamepadButton(private val gamepad: GamepadState, private val button: KCall
     val isPressed: Boolean
         get() = this.button.call(this.gamepad.current)
 
-    fun ifIsToggled(block: () -> Unit) {
+    inline fun ifIsToggled(block: () -> Unit) {
         if (this.isToggled) block()
     }
 
-    fun ifIsPressed(block: () -> Unit) {
+    inline fun ifIsPressed(block: () -> Unit) {
         if (this.isPressed) block()
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/modular/GamepadButton.kt
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/modular/GamepadButton.kt
@@ -2,6 +2,7 @@ package org.firstinspires.ftc.teamcode.modular
 
 import kotlin.reflect.KCallable
 
+@Suppress("MemberVisibilityCanBePrivate")
 class GamepadButton(private val gamepad: GamepadState, private val button: KCallable<Boolean>) {
 
     val isToggled: Boolean


### PR DESCRIPTION
1. Changed the `button` parameter to accept KCallable<Boolean> instead of KCallable<*> which will throw a compile time error if a function that does not return a boolean is passed into it. 

2. Inlined the `ifIsPressed` and `ifIsToggled` functions to avoid unnecessary object creation from the lambdas passed into them. 
